### PR TITLE
Mark the footprint as virtual in the pretty format

### DIFF
--- a/svg2mod.py
+++ b/svg2mod.py
@@ -1201,7 +1201,7 @@ class Svg2ModExportPretty( Svg2ModExport ):
     def _write_library_intro( self ):
 
         self.output_file.write( """(module {0} (layer F.Cu) (tedit {1:8X})
-  (attr smd)
+  (attr virtual)
   (descr "{2}")
   (tags {3})
 """.format(


### PR DESCRIPTION
The export currently adds (attr smd), which marks the footprint as an
SMD component (which internally sets the MOD_CMS attribute, and in the
GUI marks the component as "Normal+Insert").

This causes it to be exported in a .pos file for a pick & place machine.
Since this is just a silkscreen and not an actual component, this makes
no sense.

This commit instead sets (attr virtual) (which internally sets
MOD_VIRTUAL, and in the GUI marks the component as "Virtual") which
causes it to be ignored by various parts of kicad that iterate over
actual components.